### PR TITLE
Add support for image cache

### DIFF
--- a/CSTViOS.xcodeproj/project.pbxproj
+++ b/CSTViOS.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		499A471229DB105800C5EC70 /* Serie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499A46CB29DB01AA00C5EC70 /* Serie.swift */; };
 		499A471329DB107300C5EC70 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499A46DF29DB03A000C5EC70 /* Constants.swift */; };
 		499A471529DB110E00C5EC70 /* CSTVMatchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499A471429DB110E00C5EC70 /* CSTVMatchViewModelTests.swift */; };
+		49F5DCB529DB250300E04C90 /* CachedAsyncImage in Frameworks */ = {isa = PBXBuildFile; productRef = 49F5DCB429DB250300E04C90 /* CachedAsyncImage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -121,6 +122,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49F5DCB529DB250300E04C90 /* CachedAsyncImage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -287,6 +289,9 @@
 			dependencies = (
 			);
 			name = CSTViOS;
+			packageProductDependencies = (
+				49F5DCB429DB250300E04C90 /* CachedAsyncImage */,
+			);
 			productName = CSTViOS;
 			productReference = 499A468329DA757600C5EC70 /* CSTViOS.app */;
 			productType = "com.apple.product-type.application";
@@ -359,6 +364,9 @@
 				Base,
 			);
 			mainGroup = 499A467A29DA757600C5EC70;
+			packageReferences = (
+				49F5DCB329DB250300E04C90 /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */,
+			);
 			productRefGroup = 499A468429DA757600C5EC70 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -611,8 +619,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -620,9 +627,12 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = fabiolindemberg.CSTViOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -640,8 +650,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -649,9 +658,12 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = fabiolindemberg.CSTViOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -771,6 +783,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		49F5DCB329DB250300E04C90 /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/lorenzofiamingo/swiftui-cached-async-image";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		49F5DCB429DB250300E04C90 /* CachedAsyncImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 49F5DCB329DB250300E04C90 /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */;
+			productName = CachedAsyncImage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 499A467B29DA757600C5EC70 /* Project object */;
 }

--- a/CSTViOS/View/MatchCardView.swift
+++ b/CSTViOS/View/MatchCardView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import CachedAsyncImage
 
 struct MatchCardView: View {
     @Binding var match: Match
@@ -42,7 +43,7 @@ struct MatchCardView: View {
                 .background(Color.white.opacity(0.5))
             
             HStack {
-                AsyncImage(url: match.league.imageUrl?.url) { image in
+                CachedAsyncImage(url: match.league.imageUrl?.url) { image in
                     image
                         .resizable()
                         .scaledToFit()

--- a/CSTViOS/View/OpponentPlayersView.swift
+++ b/CSTViOS/View/OpponentPlayersView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import CachedAsyncImage
 
 struct OpponentPlayersView: View {
     @Binding var opponentPlayers: OpponentPlayers
@@ -31,7 +32,7 @@ struct OpponentPlayersView: View {
                             .foregroundColor(.white.opacity(0.5))
                     }
                     
-                    AsyncImage(url: URL(string: opponentPlayers.playerTeamOne?.imageUrl ?? "")) { image in
+                    CachedAsyncImage(url: URL(string: opponentPlayers.playerTeamOne?.imageUrl ?? "")) { image in
                         image
                             .resizable()
                             .frame(width: 55, height: 55)
@@ -58,7 +59,7 @@ struct OpponentPlayersView: View {
                     .frame(width: 200, height: 60)
                 HStack(alignment: .bottom) {
 
-                    AsyncImage(url: URL(string: opponentPlayers.playerTeamTwo?.imageUrl ?? "")) { image in
+                    CachedAsyncImage(url: URL(string: opponentPlayers.playerTeamTwo?.imageUrl ?? "")) { image in
                         image
                             .resizable()
                             .frame(width: 55, height: 55)

--- a/CSTViOS/View/TeamView.swift
+++ b/CSTViOS/View/TeamView.swift
@@ -6,13 +6,14 @@
 //
 
 import SwiftUI
+import CachedAsyncImage
 
 struct TeamView: View {
     var team: Team?
     
     var body: some View {
         VStack(alignment: .center) {
-            AsyncImage(url: URL(string: team?.imageUrl ?? "")) { image in
+            CachedAsyncImage(url: URL(string: team?.imageUrl ?? "")) { image in
                 image
                     .resizable()
                     .scaledToFit()


### PR DESCRIPTION
This enhancement really improve apps performance by enable image caching, avoid lots of http requests.

For this purpose was added the package dependency https://github.com/lorenzofiamingo/swiftui-cached-async-image/branches.

This was selected between others because it requires a minimum additional code as demonstrated in its documentation.