### PR TITLE
Create view PlayerImageView to avoid code duplicity

### DIFF
--- a/CSTViOS.xcodeproj/project.pbxproj
+++ b/CSTViOS.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		499A471329DB107300C5EC70 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499A46DF29DB03A000C5EC70 /* Constants.swift */; };
 		499A471529DB110E00C5EC70 /* CSTVMatchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499A471429DB110E00C5EC70 /* CSTVMatchViewModelTests.swift */; };
 		49F5DCB529DB250300E04C90 /* CachedAsyncImage in Frameworks */ = {isa = PBXBuildFile; productRef = 49F5DCB429DB250300E04C90 /* CachedAsyncImage */; };
+		49F5DCB729DB31D600E04C90 /* PlayerImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F5DCB629DB31D600E04C90 /* PlayerImageView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,6 +116,7 @@
 		499A470229DB0EBA00C5EC70 /* Data+decode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+decode.swift"; sourceTree = "<group>"; };
 		499A470529DB0F1200C5EC70 /* Date+utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+utils.swift"; sourceTree = "<group>"; };
 		499A471429DB110E00C5EC70 /* CSTVMatchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSTVMatchViewModelTests.swift; sourceTree = "<group>"; };
+		49F5DCB629DB31D600E04C90 /* PlayerImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerImageView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -248,6 +250,7 @@
 				499A46F529DB0B2600C5EC70 /* OpponentPlayersView.swift */,
 				499A46E429DB04D500C5EC70 /* SplashScreenView.swift */,
 				499A46ED29DB079200C5EC70 /* TeamView.swift */,
+				49F5DCB629DB31D600E04C90 /* PlayerImageView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -421,6 +424,7 @@
 				499A46F029DB081B00C5EC70 /* MatchCardView.swift in Sources */,
 				499A46D429DB024300C5EC70 /* OpponentPlayers.swift in Sources */,
 				499A470029DB0E4900C5EC70 /* JSONDecoder+customDecoder.swift in Sources */,
+				49F5DCB729DB31D600E04C90 /* PlayerImageView.swift in Sources */,
 				499A46DD29DB036C00C5EC70 /* Service.swift in Sources */,
 				499A46EC29DB069000C5EC70 /* ViewModelProtocol.swift in Sources */,
 				499A46CA29DB017B00C5EC70 /* Player.swift in Sources */,

--- a/CSTViOS/View/OpponentPlayersView.swift
+++ b/CSTViOS/View/OpponentPlayersView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import CachedAsyncImage
 
 struct OpponentPlayersView: View {
     @Binding var opponentPlayers: OpponentPlayers
@@ -32,21 +31,8 @@ struct OpponentPlayersView: View {
                             .foregroundColor(.white.opacity(0.5))
                     }
                     
-                    CachedAsyncImage(url: URL(string: opponentPlayers.playerTeamOne?.imageUrl ?? "")) { image in
-                        image
-                            .resizable()
-                            .frame(width: 55, height: 55)
-                            .clipShape(RoundedRectangle(cornerRadius: 10))
-                            .aspectRatio(0.6, contentMode: .fill)
-                    } placeholder: {
-                        Rectangle()
-                            .frame(width: 60, height: 60)
-                            .cornerRadius(10)
-                            .foregroundColor(Color("placeholder-background"))
-
-                    }
-                    .frame(width: 60, height: 60)
-                    
+                    PlayerImageView(url: URL(string: opponentPlayers.playerTeamOne?.imageUrl ?? ""),
+                              squareSize: 55)
                 }
                 .offset(x: -7, y: -8)
             }
@@ -59,20 +45,8 @@ struct OpponentPlayersView: View {
                     .frame(width: 200, height: 60)
                 HStack(alignment: .bottom) {
 
-                    CachedAsyncImage(url: URL(string: opponentPlayers.playerTeamTwo?.imageUrl ?? "")) { image in
-                        image
-                            .resizable()
-                            .frame(width: 55, height: 55)
-                            .clipShape(RoundedRectangle(cornerRadius: 10))
-                            .aspectRatio(0.6, contentMode: .fill)
-                    } placeholder: {
-                        Rectangle()
-                            .frame(width: 60, height: 60)
-                            .cornerRadius(10)
-                            .foregroundColor(Color("placeholder-background"))
-
-                    }
-                    .frame(width: 60, height: 60)
+                    PlayerImageView(url: URL(string: opponentPlayers.playerTeamOne?.imageUrl ?? ""),
+                              squareSize: 55)
 
                     VStack(alignment: .leading) {
                         Text(opponentPlayers.playerTeamTwo?.name ?? "N/A")

--- a/CSTViOS/View/PlayerImageView.swift
+++ b/CSTViOS/View/PlayerImageView.swift
@@ -1,0 +1,38 @@
+//
+//  ImageView.swift
+//  CSTViOS
+//
+//  Created by Fabio Lindemberg on 03/04/23.
+//
+
+import SwiftUI
+import CachedAsyncImage
+
+struct PlayerImageView: View {
+    var url: URL?
+    var squareSize: Double
+    
+    var body: some View {
+        CachedAsyncImage(url: url) { image in
+            image
+                .resizable()
+                .frame(width: squareSize, height: squareSize)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .scaledToFit()
+        } placeholder: {
+            Rectangle()
+                .frame(width: squareSize, height: squareSize)
+                .cornerRadius(10)
+                .foregroundColor(Color("placeholder-background"))
+            
+        }
+        .frame(width: squareSize, height: squareSize)
+    }
+}
+
+struct PlayerImageView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlayerImageView(url: URL(string: opponentPlayersMock.playerTeamOne?.imageUrl ?? ""),
+                  squareSize: 60)
+    }
+}


### PR DESCRIPTION
This PR reduce code duplicity by create a component PlayerImageView avoid duplication.
As a result beyond clean the code the code coverage was increased 🚀 from 46% to 49%.